### PR TITLE
feat: use MakeIdle() instead of Stop() for TTL expiration to respect sleep mode

### DIFF
--- a/proxy/process.go
+++ b/proxy/process.go
@@ -411,8 +411,8 @@ func (p *Process) startUnloadMonitoring() {
 				}
 
 				if time.Since(p.getLastRequestHandled()) > maxDuration {
-					p.proxyLogger.Infof("<%s> Unloading model, TTL of %ds reached", p.ID, p.config.UnloadAfter)
-					p.Stop()
+					p.proxyLogger.Infof("<%s> Putting to sleep, TTL of %ds reached", p.ID, p.config.UnloadAfter)
+					p.MakeIdle()
 					return
 				}
 			}

--- a/proxy/process.go
+++ b/proxy/process.go
@@ -411,7 +411,7 @@ func (p *Process) startUnloadMonitoring() {
 				}
 
 				if time.Since(p.getLastRequestHandled()) > maxDuration {
-					p.proxyLogger.Infof("<%s> Putting to sleep, TTL of %ds reached", p.ID, p.config.UnloadAfter)
+					p.proxyLogger.Infof("<%s> Making idle, TTL of %ds reached", p.ID, p.config.UnloadAfter)
 					p.MakeIdle()
 					return
 				}


### PR DESCRIPTION
## Problem
When a model's TTL (unload timer) expires, `Stop()` was called directly, which completely unloads the model from VRAM even when `sleepMode` is enabled in the config. This bypasses the sleep mode infrastructure entirely.

## Solution
Call `MakeIdle()` instead of `Stop()` when TTL expires. `MakeIdle()` already checks `isSleepEnabled()` and calls either:
- `Sleep()` → preserves weights in VRAM (fast wake-up, ~seconds) if sleep mode is enabled
- `Stop()` → full unload (current behavior) if sleep mode is disabled
This enables graceful sleep mode activation for idle models while maintaining backward compatibility.

## Changes
- Line 413-414 in `proxy/process.go`: Changed `p.Stop()` → `p.MakeIdle()` 
- Updated log message to say "Putting to sleep" instead of "Unloading model"

## Testing
Deployed locally with vLLM backend using `sleepMode: enable` and `ttl: 1800`. Model now enters sleep mode after 30 minutes of idle time instead of being fully unloaded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized idle process handling: processes now transition to an idle/sleep state instead of being terminated, with logs reflecting the idle transition. This reduces restart latency and improves resource efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->