### PR TITLE
proxy: rewrite alias model name in proxied requests

### DIFF
--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -646,6 +646,13 @@ func (pm *ProxyManager) proxyInferenceHandler(c *gin.Context) {
 				pm.sendErrorResponse(c, http.StatusInternalServerError, fmt.Sprintf("error rewriting model name in JSON: %s", err.Error()))
 				return
 			}
+		} else if requestedModel != modelID {
+			// Rewrite alias to real model name so the backend recognizes it
+			bodyBytes, err = sjson.SetBytes(bodyBytes, "model", modelID)
+			if err != nil {
+				pm.sendErrorResponse(c, http.StatusInternalServerError, fmt.Sprintf("error rewriting model name in JSON: %s", err.Error()))
+				return
+			}
 		}
 
 		// issue #174 strip parameters from the JSON body
@@ -795,8 +802,9 @@ func (pm *ProxyManager) proxyOAIPostFormHandler(c *gin.Context) {
 				// # issue #69 allow custom model names to be sent to upstream
 				if useModelName != "" {
 					fieldValue = useModelName
-				} else {
-					fieldValue = requestedModel
+				} else if requestedModel != modelID {
+					// Rewrite alias to real model name so the backend recognizes it
+					fieldValue = modelID
 				}
 			}
 			field, err := multipartWriter.CreateFormField(key)


### PR DESCRIPTION
When a request uses an alias, llama-swap resolves it for routing but forwards the original alias name to the backend. Backends like vLLM reject this with 404 since they don't recognize the alias.

**Update**: At maintainer request, added a new global config option `sendRealModelID: true` to enable this behavior (disabled by default to avoid breaking existing configurations).

- Default is `false` (preserves existing behavior)
- When set to `true`, rewrites alias to real model ID in both JSON and multipart request bodies
- `useModelName` still takes precedence when set

Upstream PR: https://github.com/mostlygeek/llama-swap/pull/638